### PR TITLE
bumped version to 0.2.1

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -4,7 +4,7 @@ This SDK Contains automatically generated sources & documents with the [Swagger 
 
 - API version: 0.2.0
 - Package version: 0.2.0
-- Build date: 2016-07-07T16:36:02.764+09:00
+- Build date: 2016-07-07T17:22:13.863+09:00
 - Build package: class io.swagger.codegen.languages.JavascriptClientCodegen
 
 ## Getting Started

--- a/builder/templates/package.mustache
+++ b/builder/templates/package.mustache
@@ -1,7 +1,7 @@
 {
   "name": "webida-restful-api",
-  "version": "0.2.0",
-  "description": "{{{projectDescription}}}",
+  "version": "0.2.1",
+  "description": "Webida Restful API Spec & generated clients",
   "license": "Apache-2.0",
   "main": "{{sourceFolder}}{{#invokerPackage}}/{{invokerPackage}}{{/invokerPackage}}/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webida-restful-api",
-  "version": "0.2.0",
-  "description": "Restful_API_for_Webida_clients_to_use_servers_data__features",
+  "version": "0.2.1",
+  "description": "Webida Restful API Spec & generated clients",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
- due to npm problems, we cannot re-publish same version
- changed package description not to use '_'
